### PR TITLE
fix start_cursor request type (issue:#498)

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -166,7 +166,7 @@ export default class Client {
     const url = new URL(`${this.#prefixUrl}${path}`)
     if (query) {
       for (const [key, value] of Object.entries(query)) {
-        if (value !== undefined) {
+        if (value !== undefined && value !== null) {
           if (Array.isArray(value)) {
             value.forEach(val =>
               url.searchParams.append(key, decodeURIComponent(val))
@@ -615,6 +615,8 @@ export default class Client {
  * Type aliases to support the generic request interface.
  */
 type Method = "get" | "post" | "patch" | "delete"
-type QueryParams = Record<string, string | number | string[]> | URLSearchParams
+type QueryParams =
+  | Record<string, string | number | string[] | null>
+  | URLSearchParams
 
 type WithAuth<P> = P & { auth?: string }

--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -9956,7 +9956,7 @@ export const getUser = {
 } as const
 
 type ListUsersQueryParameters = {
-  start_cursor?: string
+  start_cursor?: string | null
   page_size?: number
 }
 
@@ -10521,7 +10521,7 @@ type GetPagePropertyPathParameters = {
 }
 
 type GetPagePropertyQueryParameters = {
-  start_cursor?: string
+  start_cursor?: string | null
   page_size?: number
 }
 
@@ -10848,7 +10848,7 @@ type ListBlockChildrenPathParameters = {
 }
 
 type ListBlockChildrenQueryParameters = {
-  start_cursor?: string
+  start_cursor?: string | null
   page_size?: number
 }
 
@@ -11215,7 +11215,7 @@ type QueryDatabaseBodyParameters = {
     | PropertyFilter
     | TimestampCreatedTimeFilter
     | TimestampLastEditedTimeFilter
-  start_cursor?: string
+  start_cursor?: string | null
   page_size?: number
   archived?: boolean
   in_trash?: boolean
@@ -11256,7 +11256,7 @@ export const queryDatabase = {
 } as const
 
 type ListDatabasesQueryParameters = {
-  start_cursor?: string
+  start_cursor?: string | null
   page_size?: number
 }
 
@@ -11475,7 +11475,7 @@ type SearchBodyParameters = {
     direction: "ascending" | "descending"
   }
   query?: string
-  start_cursor?: string
+  start_cursor?: string | null
   page_size?: number
   filter?: { property: "object"; value: "page" | "database" }
 }
@@ -11527,7 +11527,7 @@ export const createComment = {
 
 type ListCommentsQueryParameters = {
   block_id: IdRequest
-  start_cursor?: string
+  start_cursor?: string | null
   page_size?: number
 }
 


### PR DESCRIPTION
Issue on https://github.com/makenotion/notion-sdk-js/issues/498

## Description
This PR resolves a type mismatch issue encountered when using the start_cursor in database.query.
The current implementation leads to a conflict between string | undefined and string | null in various scenarios involving the cursor.

## Changes Made
Updated the type for start_cursor in QueryParameters to accept both null and undefined.

## Expected Behavior:
With this change, you will no longer face typing issues when assigning next_cursor from a query response to a variable.

```typescript
  let databaseId = "<some_id>"
  let entries = []
  let cursor: string | null = null

  while (true) {
    const { results, has_more, next_cursor }: QueryDatabaseResponse =
      await notion.databases.query({
        database_id: databaseId,
        start_cursor: cursor,
      })

    cursor = next_cursor  // Now this works without typing issues
    entries.push(...results)

    if (!has_more) {
      break
    }
  }

  return entries
```